### PR TITLE
Allows multi-type generics (ie <T, R, ...>) in method parameters

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -184,9 +184,35 @@ class Extractor {
         return {'name': name, 'scope': scope, 'type': type, 'visibility': visibility}
     }
 
+    _parseCommaToBar(params) {
+        let refactorString = '';
+        let foundArrow = false;
+        for (let param of params) {
+            if (!foundArrow) {
+                if (param === ',') {
+                    refactorString += '|'
+                } else {
+                    refactorString += param
+                }
+            }
+            if (param === '<') {
+                foundArrow = true
+            }
+            if (foundArrow) {
+                if (param !== '<') {
+                    refactorString += param;
+                }
+            }
+            if (param === '>') {
+                foundArrow = false
+            }
+        }
+        return refactorString;
+    }
+
     extractParameters(params) {
         let resultParams = []
-        for (let param of params.split(',').map(x => x.trim())) {
+        for (let param of this._parseCommaToBar(params).split('|').map(x => x.trim())) {
             let aval = param.split(':').map(x => x.trim())
             if (aval.length != 2) {
                 throw new ParseError(this.lineNumber, "Unknow param format " + params)

--- a/parser.js
+++ b/parser.js
@@ -252,7 +252,6 @@ class Extractor {
     }
 
     extractParameters(params) {
-        console.log(this._parseCommaToBar(params))
         let resultParams = []
         for (let param of this._parseCommaToBar(params).split('|').map(x => x.trim())) {
             let aval = param.split(':').map(x => x.trim())

--- a/parser.js
+++ b/parser.js
@@ -203,14 +203,14 @@ class Extractor {
                         return {
                             stringGenericType,
                             index: i,
-                            isGenericType: 0
+                            isGenericType: 1
                         }
                     }
                 }
                 return {
                     stringGenericType,
                     index: i,
-                    isGenericType: 1
+                    isGenericType: 0
                 }
             }
         }
@@ -239,17 +239,20 @@ class Extractor {
                 leftArrow = 1
             }
             if (leftArrow) {
-                refactorString += params[i]
-            }
-
-            if (params[i] === '>') {
-                leftArrow = 0
+                if (params[i] === ',') {
+                    refactorString += '|'
+                } else {
+                    if (params[i] !== undefined) {
+                        refactorString += params[i]
+                    }
+                }
             }
         }
         return refactorString
     }
 
     extractParameters(params) {
+        console.log(this._parseCommaToBar(params))
         let resultParams = []
         for (let param of this._parseCommaToBar(params).split('|').map(x => x.trim())) {
             let aval = param.split(':').map(x => x.trim())


### PR DESCRIPTION
Related issue

#26 

What is the purpose of this pull request?
Allow multi-type generics (ie <T, R, ...>) in method parameters

What was done?
add method _parseCommaToBar in parser.js
line 215 - used _parseCommaToBar in the parameter inside the method extractParameters loop, and change split(",") to split("|").